### PR TITLE
活动倒计时bug

### DIFF
--- a/src/components/CountDown.vue
+++ b/src/components/CountDown.vue
@@ -177,6 +177,7 @@
 					let _e = Date.now();
 					let diffPerFunc = _e - _s;
 					setTimeout(() => {
+						endTime -= 0;
 						if (type) {
 							this.runTime(this.end, (endTime += 1000), callFun, true);
 						} else {


### PR DESCRIPTION
typeof  endTime == "string" ,导致时间戳计算有误
`endTime += 1000`